### PR TITLE
fixed grid-layout mistake

### DIFF
--- a/app/views/listing-skin-panel.blade.php
+++ b/app/views/listing-skin-panel.blade.php
@@ -1,7 +1,7 @@
 <div class="row">
     @foreach ($skins as $key => $skin)
         @if ($key < 12)
-        <div class="col-sm-5 col-md-3">
+        <div class="col-sm-6 col-md-3">
             <div class="thumbnail">
                 <img style="height:155px;" src="{{$skin->thumbnail == 1 ? last_modified('/previews-content/'.$skin->id.'/thumbnails.png') : last_modified('/previews-content/no-thumbnails.png')}}" alt="...">
                 <div class="caption">


### PR DESCRIPTION
col-sm-5 wouldn't fill up the 12-column-grid layout, leaving a 2 column wide space on the right side on small devices.
